### PR TITLE
Open in sidebar on shift click

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -31,7 +31,6 @@ export default {
     const d = new Date()
     return {
       ready: false,
-      shiftKey: false,
       preferredDateFormat: null,
       journals: null,
       opts: {
@@ -73,17 +72,9 @@ export default {
       immediate: true,
     })
 
-    document.addEventListener('keydown', this._onKeyDown)
-    document.addEventListener('keyup', this._onKeyUp)
-
     logseq.on('ui:visible:changed', ({ visible }) => {
       visible && (this.ready = true, refreshConfigs())
     })
-  },
-
-  destroyed() {
-    document.removeEventListener('keydown', this._onKeyDown)
-    document.removeEventListener('keyup', this._onKeyUp)
   },
 
   methods: {
@@ -145,15 +136,7 @@ export default {
       !inner && logseq.hideMainUI()
     },
 
-    _onKeyDown ({ shiftKey }) {
-      this.shiftKey = shiftKey
-    },
-
-    _onKeyUp ({ shiftKey }) {
-      this.shiftKey = shiftKey
-    },
-
-    async _onDaySelect ({ id }) {
+    async _onDaySelect ({ event, id }) {
       this.date = id
 
       let t = id
@@ -175,7 +158,7 @@ export default {
       }
 
       logseq.hideMainUI()
-      if (this.shiftKey) {
+      if (event.shiftKey) {
         var page = await logseq.Editor.getPage(t)
         if (page == null) {
           // Journal entry does not exist. Create it.


### PR DESCRIPTION
If an entry in the calendar is clicked with shift pressed down,
open that day's journal in the sidebar.

Because the openInRightSidebar only accepts UUIDs,
we have to retrieve or create the day's page to get its UUID.

Resolves #4

---

Demo:
![shift-click](https://user-images.githubusercontent.com/41730/148584653-a5a50c62-81ff-4f8e-893a-b5979782ccdb.gif)

