### PR TITLE
fix: journal creation when E is involved

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "logseq-journals-calendar",
   "description": "A simple journals calendar plugin for Logseq.",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "main": "dist/index.html",
   "author": "xyhp915",
   "scripts": {

--- a/src/App.vue
+++ b/src/App.vue
@@ -213,7 +213,7 @@ export default {
             .replace('EEEE', 'dddd')
             .replace('EEE', 'ddd')
             .replace('EE', 'dd')
-            .replace('E', 'dd')
+            .replace('E', 'ddd')
 
         t = dayjs(id).format(format)
       }


### PR DESCRIPTION
My date format uses a single 'E', which corresponds the strings like this: "2022-07-08, Fri", that is, a single 'E' means 'ddd', hence this PR.