### PR TITLE
feat: add an option to keep calendar open after selecting a date

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -43,6 +43,7 @@ export default {
     const {
       props, firstDayOfWeek,
       backgroundColorOfContainerLight, backgroundColorOfContainerDark,
+      keepOpenOnSelect,
     } = logseq.settings
 
     return {
@@ -74,6 +75,7 @@ export default {
         month: d.getMonth() + 1,
         year: d.getFullYear(),
       },
+      keepOpenOnSelect,
     }
   },
 
@@ -111,11 +113,13 @@ export default {
       const {
         props, firstDayOfWeek,
         backgroundColorOfContainerDark, backgroundColorOfContainerLight,
+        keepOpenOnSelect,
       } = settings || {}
 
       this.opts[`first-day-of-week`] = firstDayOfWeek
       this.bgColor.dark = backgroundColorOfContainerDark
       this.bgColor.light = backgroundColorOfContainerLight
+      this.keepOpenOnSelect = keepOpenOnSelect
     })
 
     setTimeout(refreshConfigs, 1000)
@@ -225,7 +229,9 @@ export default {
         t = dayjs(id).format(format)
       }
 
-      logseq.hideMainUI()
+      if (!this.keepOpenOnSelect) {
+        logseq.hideMainUI()
+      }
 
       if (event.shiftKey) {
         let page = await logseq.Editor.getPage(t)

--- a/src/main.js
+++ b/src/main.js
@@ -48,6 +48,12 @@ const settingsSchema = [
     title: 'Hotkey to open calendar',
     description: 'Hotkey to open calendar',
     default: null,
+  }, {
+    key: 'keepOpenOnSelect',
+    type: 'boolean',
+    title: '',
+    description: 'Keep the calendar open after selecting a date',
+    default: false,
   }]
 
 let app = null


### PR DESCRIPTION
Related: https://github.com/xyhp915/logseq-journals-calendar/issues/22

I had wanted to keep plugin UI open while browsing and editing journals, but it seems not possible. This is a workaround, which seems good enough.