### PR TITLE
Add option for showing week numbers in ISO format

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -45,6 +45,7 @@ export default {
       backgroundColorOfContainerLight, backgroundColorOfContainerDark,
       keepOpenOnSelect,
       showWeekNumbers,
+      showIsoWeeknumbers,
     } = logseq.settings
 
     return {
@@ -59,6 +60,7 @@ export default {
         color: 'orange',
         [`is-dark`]: false,
         [`show-weeknumbers`]: showWeekNumbers,
+        [`show-iso-weeknumbers`]: showIsoWeeknumbers,
         attributes: [
           {
             dot: true,
@@ -125,10 +127,12 @@ export default {
         backgroundColorOfContainerDark, backgroundColorOfContainerLight,
         keepOpenOnSelect,
         showWeekNumbers,
+        showIsoWeeknumbers,
       } = settings || {}
 
       this.opts[`first-day-of-week`] = firstDayOfWeek
       this.opts[`show-weeknumbers`] = showWeekNumbers
+      this.opts[`show-iso-weeknumbers`] = showIsoWeeknumbers
       this.bgColor.dark = backgroundColorOfContainerDark
       this.bgColor.light = backgroundColorOfContainerLight
       this.keepOpenOnSelect = keepOpenOnSelect

--- a/src/main.js
+++ b/src/main.js
@@ -60,6 +60,12 @@ const settingsSchema = [
     title: '',
     description: 'Show week numbers in calendar',
     default: false,
+  },{
+    key: 'showIsoWeeknumbers',
+    type: 'boolean',
+    title: '',
+    description: 'Show week number in ISO format',
+    default: false,
   }]
 
 let app = null


### PR DESCRIPTION
Option to show week numbers in ISO format. 

see [iso-weeknumbers](https://vcalendar.io/calendar/layouts.html#iso-weeknumbers)