### PR TITLE
respect `keepOpenOnSelect` when holding shift

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -279,7 +279,9 @@ export default {
 
       if (event.shiftKey) {
         logseq.Editor.openInRightSidebar(page?.uuid)
-        logseq.hideMainUI()
+        if (!this.keepOpenOnSelect) {
+          logseq.hideMainUI()
+        }
       } else {
         if (isDbGraph || supportDb) {
           t = page?.uuid


### PR DESCRIPTION
Motivation: I do a weekly review which begins by opening this plugin and shift-clicking each day that is included. I'd like it to respect my "keep open" setting for this. 